### PR TITLE
Drop comment referring to OpenPGP "embedded filename"

### DIFF
--- a/gnumed/gnumed/client/pycommon/gmCrypto.py
+++ b/gnumed/gnumed/client/pycommon/gmCrypto.py
@@ -283,7 +283,6 @@ def gpg_decrypt_file(filename=None, verbose=False, target_ext=None):
 		'--enable-progress-filter',
 		'--decrypt',
 		'--output', filename_decrypted
-		##'--use-embedded-filename'				# not all encrypted files carry a filename
 	]
 	if verbose:
 		args.extend ([


### PR DESCRIPTION
The filename embedded in an OpenPGP literal data packet is unsafe to use generally, and can cause a security problem if it's requested.

GnuPG upstream has explicitly said this option shouldn't be used anyway:  https://dev.gnupg.org/T4500

And i'm encouraging GnuPG to deprecate it and remove it, due to the overall hazard it presents:

https://dev.gnupg.org/T6972

There's no sense in keeping the comment in the GNUmed codebase.