### PR TITLE
small fix in dark theme patches - now login text color is blue only w/ light theme

### DIFF
--- a/gnumed/gnumed/client/wxGladeWidgets/wxgPatientOverviewPnl.py
+++ b/gnumed/gnumed/client/wxGladeWidgets/wxgPatientOverviewPnl.py
@@ -39,7 +39,7 @@ class wxgPatientOverviewPnl(wx.ScrolledWindow):
 		# begin wxGlade: wxgPatientOverviewPnl.__set_properties
 		self.SetSize((400, 300))
 		self.SetScrollRate(10, 10)
-		self._LCTRL_problems.SetBackgroundColour(wx.Colour(255, 238, 180))
+		# self._LCTRL_problems.SetBackgroundColour(wx.Colour(255, 238, 180))  # already set in gmPatOverviewWidgets.py
 		# end wxGlade
 
 	def __do_layout(self):

--- a/gnumed/gnumed/client/wxpython/gmAuthWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmAuthWidgets.py
@@ -638,7 +638,7 @@ class cLoginPanel(wx.Panel):
 	#----------------------------------------------------------
 	def __set_label_color(self, label):
 		"""Set adaptive label color based on system theme background."""
-		if gmGuiHelpers.is_probably_dark_theme():
+		if not gmGuiHelpers.is_probably_dark_theme():
 			label.SetForegroundColour(wx.Colour(35, 35, 142))  # orig dark blue
 
 	#----------------------------------------------------


### PR DESCRIPTION
Hello! 

Just a very small change in gmAuthWidgets, __set_label_color() method:
- Added "not" to the condition.
Before, if the condition was true (if the theme was dark) it set the text color to dark blue.
Now, it only sets it to dark blue if the condition is not true (if the theme is light).
Tested locally, works reliably!

Also in wxgPatientOverviewPnl.py:
- just commented a line that set the background color for the "Active Problems:" section
Color change according to system theme still worked even with that line "on"/not commented.
But, since the color is already set in another file, thought maybe it's better to comment this redundancy?

Thank you for integrating and adapting the previous proposed fixes!! :)
