### PR TITLE
UI: odd column widths patches

### DIFF
--- a/gnumed/gnumed/client/wxpython/gmAllergyWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmAllergyWidgets.py
@@ -375,12 +375,7 @@ class cAllergyManagerDlg(wxgAllergyManagerDlg.wxgAllergyManagerDlg):
 			self._RBTN_unknown.Enable(True)
 			self._RBTN_none.Enable(True)
 
-		self._LCTRL_allergies.set_column_widths (widths = [
-			wx.LIST_AUTOSIZE,
-			wx.LIST_AUTOSIZE,
-			wx.LIST_AUTOSIZE,
-			wx.LIST_AUTOSIZE
-		])
+		self._LCTRL_allergies.set_column_widths()
 
 		self._PNL_edit_area.clear()
 		self._BTN_delete.Enable(False)

--- a/gnumed/gnumed/client/wxpython/gmAutoHintWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmAutoHintWidgets.py
@@ -341,7 +341,7 @@ class cDynamicHintListDlg(wxgDynamicHintListDlg.wxgDynamicHintListDlg):
 	#------------------------------------------------------------
 	def __init_ui(self):
 		self._LCTRL_hints.set_columns([_('Hint'), _('Source')])
-		self._LCTRL_hints.set_column_widths([wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE])
+		self._LCTRL_hints.set_column_widths()
 		self._LCTRL_hints.set_resize_column(column = 0)
 		self._LCTRL_hints.select_callback = self._on_hint_selected
 		self._LCTRL_hints.deselect_callback = self._on_hint_deselected

--- a/gnumed/gnumed/client/wxpython/gmDemographicsWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmDemographicsWidgets.py
@@ -119,7 +119,7 @@ def manage_tag_images(parent=None):
 			t['pk_tag_image']
 		] for t in tags ]
 		lctrl.set_string_items(items)
-		lctrl.set_column_widths(widths = [wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE_USEHEADER, wx.LIST_AUTOSIZE_USEHEADER, wx.LIST_AUTOSIZE])
+		lctrl.set_column_widths()
 		lctrl.set_data(tags)
 
 	#------------------------------------------------------------

--- a/gnumed/gnumed/client/wxpython/gmDocumentWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmDocumentWidgets.py
@@ -2663,10 +2663,12 @@ class cPACSPluginPnl(wxgPACSPluginPnl, gmRegetMixin.cRegetOnPaintMixin):
 		self._LCTRL_studies.set_columns(columns = [_('Date'), _('Description'), _('Organization'), _('Authority')])
 		self._LCTRL_studies.select_callback = self._on_studies_list_item_selected
 		self._LCTRL_studies.deselect_callback = self._on_studies_list_item_deselected
+		self._LCTRL_studies.set_column_widths()
 
 		self._LCTRL_series.set_columns(columns = [_('Time'), _('Method'), _('Body part'), _('Description')])
 		self._LCTRL_series.select_callback = self._on_series_list_item_selected
 		self._LCTRL_series.deselect_callback = self._on_series_list_item_deselected
+		self._LCTRL_series.set_column_widths()
 
 		self._LCTRL_details.set_columns(columns = [_('DICOM field'), _('Value')])
 		self._LCTRL_details.set_column_widths()

--- a/gnumed/gnumed/client/wxpython/gmDocumentWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmDocumentWidgets.py
@@ -496,8 +496,8 @@ class cEditDocumentTypesPnl(wxgEditDocumentTypesPnl.wxgEditDocumentTypesPnl):
 
 		if len(doc_types) > 0:
 			self._LCTRL_doc_type.set_data(data = doc_types)
-			self._LCTRL_doc_type.SetColumnWidth(0, wx.LIST_AUTOSIZE)
-			self._LCTRL_doc_type.SetColumnWidth(1, wx.LIST_AUTOSIZE)
+			self._LCTRL_doc_type.SetColumnWidth(0, wx.LIST_AUTOSIZE_USEHEADER)
+			self._LCTRL_doc_type.SetColumnWidth(1, wx.LIST_AUTOSIZE_USEHEADER)
 			self._LCTRL_doc_type.SetColumnWidth(2, wx.LIST_AUTOSIZE_USEHEADER)
 			self._LCTRL_doc_type.SetColumnWidth(3, wx.LIST_AUTOSIZE_USEHEADER)
 

--- a/gnumed/gnumed/client/wxpython/gmExportAreaWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmExportAreaWidgets.py
@@ -275,7 +275,7 @@ class cExportAreaExportToMediaDlg(wxgExportAreaExportToMediaDlg.wxgExportAreaExp
 		)
 		self._LBL_header.Label = msg
 		self._LCTRL_removable_media.set_columns([_('Type'), _('Medium'), _('Details')])
-		self._LCTRL_removable_media.set_column_widths([wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE])
+		self._LCTRL_removable_media.set_column_widths()
 		self._LCTRL_removable_media.set_resize_column()
 		self._LCTRL_removable_media.select_callback = self._on_media_selected
 		self._LCTRL_removable_media.deselect_callback = self._on_media_deselected
@@ -1513,7 +1513,7 @@ class cExportAreaPluginPnl(wxgExportAreaPluginPnl.wxgExportAreaPluginPnl, gmRege
 				i['description']
 			] for i in items
 		])
-		self._LCTRL_items.set_column_widths([wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE])
+		self._LCTRL_items.set_column_widths()
 		self._LCTRL_items.set_data(items)
 		self._LCTRL_items.RestoreItemSelection()
 		self._LCTRL_items.RestoreSortState()
@@ -1672,7 +1672,7 @@ class cPrintMgrPluginPnl(wxgPrintMgrPluginPnl.wxgPrintMgrPluginPnl, gmRegetMixin
 				] for p in printouts ]
 		self._LCTRL_printouts.set_columns(columns)
 		self._LCTRL_printouts.set_string_items(items)
-		self._LCTRL_printouts.set_column_widths([wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE])
+		self._LCTRL_printouts.set_column_widths()
 		self._LCTRL_printouts.set_data(printouts)
 		self._LCTRL_printouts.SetFocus()
 		return True

--- a/gnumed/gnumed/client/wxpython/gmListWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmListWidgets.py
@@ -1994,10 +1994,11 @@ class cReportListCtrl(DnDMixin, listmixins.ListCtrlAutoWidthMixin, cColumnSorter
 			return
 
 		# default policy !
-		if self.GetItemCount() == 0:
-			width_type = wx.LIST_AUTOSIZE_USEHEADER
-		else:
-			width_type = wx.LIST_AUTOSIZE
+		#if self.GetItemCount() == 0:
+		#	width_type = wx.LIST_AUTOSIZE_USEHEADER
+		#else:
+		#	width_type = wx.LIST_AUTOSIZE
+		width_type = wx.LIST_AUTOSIZE_USEHEADER
 		for idx in range(self.GetColumnCount()):
 			self.SetColumnWidth(idx, width_type)
 

--- a/gnumed/gnumed/client/wxpython/gmMeasurementWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmMeasurementWidgets.py
@@ -858,7 +858,7 @@ class cMeasurementsAsListPnl(wxgMeasurementsAsListPnl, gmRegetMixin.cRegetOnPain
 			data.append({'data': r, 'formatted': r.format(with_source_data = True)})
 
 		self._LCTRL_results.set_string_items(items)
-		self._LCTRL_results.set_column_widths([wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE])
+		self._LCTRL_results.set_column_widths()
 		self._LCTRL_results.set_data(data)
 		if len(items) > 0:
 			self._LCTRL_results.Select(idx = 0, on = 1)
@@ -1077,7 +1077,7 @@ class cMeasurementsByDayPnl(wxgMeasurementsByDayPnl, gmRegetMixin.cRegetOnPaintM
 
 		self._LCTRL_results.set_string_items(items)
 		self._LCTRL_results.set_column_label(1, _('Test (%s%s)') % (gmTools.u_sum, len(items)))
-		self._LCTRL_results.set_column_widths([wx.LIST_AUTOSIZE_USEHEADER, wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE])
+		self._LCTRL_results.set_column_widths()
 		self._LCTRL_results.set_data(data)
 		self._LCTRL_results.Select(idx = 0, on = 1)
 
@@ -1242,7 +1242,7 @@ class cMeasurementsByIssuePnl(wxgMeasurementsByIssuePnl, gmRegetMixin.cRegetOnPa
 			data.append({'data': r, 'formatted': r.format(with_source_data = True)})
 
 		self._LCTRL_results.set_string_items(items)
-		self._LCTRL_results.set_column_widths([wx.LIST_AUTOSIZE_USEHEADER, wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE])
+		self._LCTRL_results.set_column_widths()
 		self._LCTRL_results.set_data(data)
 		self._LCTRL_results.Select(idx = 0, on = 1)
 		self._TCTRL_measurements.SetValue(self._LCTRL_results.get_item_data(item_idx = 0)['formatted'])
@@ -1504,7 +1504,7 @@ class cMeasurementsAsMostRecentListPnl(wxgMeasurementsAsMostRecentListPnl, gmReg
 			data.append({'data': r, 'formatted': tt})
 
 		self._LCTRL_results.set_string_items(items)
-		self._LCTRL_results.set_column_widths([wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE])
+		self._LCTRL_results.set_column_widths()
 		self._LCTRL_results.set_data(data)
 
 		if len(items) > 0:
@@ -4698,7 +4698,7 @@ class cTestPanelEAPnl(wxgTestPanelEAPnl.wxgTestPanelEAPnl, gmEditArea.cGenericEd
 	#----------------------------------------------------------------
 	def __init_ui(self):
 		self._LCTRL_loincs.set_columns([_('LOINC'), _('Term'), _('Units')])
-		self._LCTRL_loincs.set_column_widths(widths = [wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE])
+		self._LCTRL_loincs.set_column_widths()
 		#self._LCTRL_loincs.set_resize_column(column = 2)
 		self._LCTRL_loincs.delete_callback = self._remove_loincs_from_list
 		self.__refresh_loinc_list()

--- a/gnumed/gnumed/client/wxpython/gmOrganizationWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmOrganizationWidgets.py
@@ -250,7 +250,7 @@ class cOrgUnitsManagerPnl(gmListWidgets.cGenericListManagerPnl):
 		] for u in units ]
 
 		self._LCTRL_items.set_string_items(items)
-		self._LCTRL_items.set_column_widths(widths = [wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE])
+		self._LCTRL_items.set_column_widths()
 		self._LCTRL_items.set_data(units)
 
 		for idx in range(len(units)):
@@ -829,7 +829,7 @@ class cOrganizationsManagerPnl(gmListWidgets.cGenericListManagerPnl):
 		orgs = gmOrganization.get_orgs(order_by = 'organization, l10n_category')
 		items = [ [o['organization'], o['l10n_category'], o['pk_org']] for o in orgs ]
 		self._LCTRL_items.set_string_items(items)
-		self._LCTRL_items.set_column_widths(widths = [wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE])
+		self._LCTRL_items.set_column_widths()
 		self._LCTRL_items.set_data(orgs)
 
 		for idx in range(len(orgs)):

--- a/gnumed/gnumed/client/wxpython/gmPatSearchWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmPatSearchWidgets.py
@@ -237,7 +237,7 @@ class cSelectPersonFromListDlg(wxgSelectPersonFromListDlg.wxgSelectPersonFromLis
 				self._LCTRL_persons.SetItem(row_num, 6, '??')
 
 		for col in range(len(self.__cols)):
-			self._LCTRL_persons.SetColumnWidth(col, wx.LIST_AUTOSIZE)
+			self._LCTRL_persons.SetColumnWidth(col, wx.LIST_AUTOSIZE_USEHEADER)
 
 		self._BTN_select.Enable(False)
 		self._LCTRL_persons.SetFocus()
@@ -317,7 +317,7 @@ class cSelectPersonDTOFromListDlg(wxgSelectPersonDTOFromListDlg.wxgSelectPersonD
 			self._LCTRL_persons.SetItem(row_num, 4, gmTools.coalesce(dto.gender, ''))
 
 		for col in range(len(self.__cols)):
-			self._LCTRL_persons.SetColumnWidth(col, wx.LIST_AUTOSIZE)
+			self._LCTRL_persons.SetColumnWidth(col, wx.LIST_AUTOSIZE_USEHEADER)
 
 		self._BTN_select.Enable(False)
 		self._LCTRL_persons.SetFocus()

--- a/gnumed/gnumed/client/wxpython/gmWaitingListWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmWaitingListWidgets.py
@@ -188,7 +188,7 @@ class cWaitingListPnl(wxgWaitingListPnl.wxgWaitingListPnl, gmRegetMixin.cRegetOn
 			_('Born'),
 			_('Comment')
 		])
-		self._LCTRL_patients.set_column_widths(widths = [wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE_USEHEADER, wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE])
+		self._LCTRL_patients.set_column_widths()
 		self._LCTRL_patients.item_tooltip_callback = self._on_get_list_tooltip
 		self._PRW_zone.add_callback_on_selection(callback = self._on_zone_selected)
 		self._PRW_zone.add_callback_on_lose_focus(callback = self._on_zone_selected)

--- a/gnumed/gnumed/client/wxpython/gui/gmXdtViewer.py
+++ b/gnumed/gnumed/client/wxpython/gui/gmXdtViewer.py
@@ -24,6 +24,7 @@ from Gnumed.pycommon import gmDispatcher, gmTools
 from Gnumed.business import gmXdtMappings, gmXdtObjects
 from Gnumed.wxGladeWidgets import wxgXdtListPnl
 from Gnumed.wxpython import gmAccessPermissionWidgets
+from Gnumed.wxpython import gmListWidgets
 
 
 _log = logging.getLogger('gm.ui')
@@ -45,8 +46,8 @@ class cXdtListPnl(wxgXdtListPnl.wxgXdtListPnl):
 		self.__init_ui()
 	#--------------------------------------------------------------
 	def __init_ui(self):
-		for col in range(len(self.__cols)):
-			self._LCTRL_xdt.InsertColumn(col, self.__cols[col])
+		self._LCTRL_xdt.set_columns(columns=self.__cols)
+		self._LCTRL_xdt.set_column_widths()
 	#--------------------------------------------------------------
 	# external API
 	#--------------------------------------------------------------


### PR DESCRIPTION
Hello, Karsten!

Sometimes, column widths adapt to the content _only_, resulting in hidden header text when the column content is too short (or shorter than the header text's width).

These changes/proposals make it so that columns have a _minimum_ width equal to the header;
and if the contents surprass that width, then it adapts to the widths of the contents instead.

I made it so gmListWidgets defaults to column width wx.LIST_AUTOSIZE_USEHEADER, and in consequence, all usages of that library to set column widths -- usage of xxx.set_column_widths() -- autosize to use header by default. Also some more manual changes where gmListWidgets was not used to create/set widths of columns.

Some screens attached to show effect with the changes...

<img width="721" height="117" alt="column_widths_before" src="https://github.com/user-attachments/assets/10d57767-85ea-4dc7-9ec2-d4889a96ab25" />
<img width="911" height="141" alt="column_widths_after" src="https://github.com/user-attachments/assets/de7304be-9669-4830-b9c4-d16a44c33bc1" />

This has improved, for me:
- visibility of columns
- overall neatness of the UI and UX

Happy (delayed) New Year,

María