### PR TITLE
small fix: permisstion error in function run_bootstrapper() - bootstrap-latest.sh

### DIFF
--- a/gnumed/gnumed/server/bootstrap/bootstrap-latest.sh
+++ b/gnumed/gnumed/server/bootstrap/bootstrap-latest.sh
@@ -105,7 +105,7 @@ function drop_intermediate_databases () {
 function run_bootstrapper () {
 	LOG="${GM_LOG_BASE}/bootstrap-latest.log"
 	CONF="bootstrap-latest.conf"
-	./bootstrap_gm_db_system.py --log-file=${LOG} --conf-file=${CONF} --${QUIET}
+	python3 ./bootstrap_gm_db_system.py --log-file=${LOG} --conf-file=${CONF} --${QUIET}
 	RESULT="$?"
 	if test "${RESULT}" != "0" ; then
 		echo "Bootstrapping \"gnumed_v${VER}\" did not finish successfully (${RESULT}). Aborting."


### PR DESCRIPTION
- small, one-word fix: just added 'python3' at the start of line 108
- tested on trixie and bookworm
- output error before fix:
(...)
./bootstrap-latest.sh: line 108: ./bootstrap_gm_db_system.py: Permission denied
Bootstrapping "gnumed_v23" did not finish successfully (126). Aborting.