### PR TITLE
small fix: NameError on execution

### DIFF
--- a/gnumed/gnumed/server/bootstrap/bootstrap_gm_db_system.py
+++ b/gnumed/gnumed/server/bootstrap/bootstrap_gm_db_system.py
@@ -152,7 +152,7 @@ DROP INDEX IF EXISTS %(idx_schema)s.%(idx_name)s CASCADE;
 CREATE INDEX %(idx_name)s ON %(idx_schema)s.%(idx_table)s(%(idx_col)s);
 """
 
-__MSG_create_gm_dbo = """The database owner [%s] must be created.
+_MSG_create_gm_dbo = """The database owner [%s] must be created.
 
 You will have to provide a new password for it.
 
@@ -456,7 +456,7 @@ class cPostgresqlCluster:
 	#--------------------------------------------------------------
 	def __create_gm_dbo(self):
 		if not gmPG2.user_role_exists(user_role = _GM_DBO_ROLE, link_obj = self.conn_superuser_at_maintenance_db):
-			print_msg(__MSG_create_gm_dbo)
+			print_msg(_MSG_create_gm_dbo)
 			_gm_dbo_pwd = get_gm_dbo_password()
 			if not gmPG2.create_user_role(user_role = _GM_DBO_ROLE, password = _gm_dbo_pwd, link_obj = self.conn_superuser_at_maintenance_db):
 				return False


### PR DESCRIPTION
- just removed one underscore from "__MSG_create_gm_dbo" variable
- __MSG_create_gm_dbo -> _MSG_create_gm_dbo
- tested and works on trixie and bookworm

- error before fix, excerpt from log:

2026-02-25 21:12:32  INFO      gm.db         [140537027895552 MainThread]  (/home/jessie13v2/Documents/gnumed/gnumed/Gnumed/pycommon/gmPG2.py::role_exists() #821): role [gm-dbo] does not exist
2026-02-25 21:12:32  ERROR     gm.bootstrapper  [140537027895552 MainThread]  (/home/jessie13v2/Documents/gnumed/gnumed/server/bootstrap/./bootstrap_gm_db_system.py::<module>() #1722): unhandled exception caught, shutting down connections
Traceback (most recent call last):
  File "/home/jessie13v2/Documents/gnumed/gnumed/server/bootstrap/./bootstrap_gm_db_system.py", line 1720, in <module>
    main()
    ~~~~^^
  File "/home/jessie13v2/Documents/gnumed/gnumed/server/bootstrap/./bootstrap_gm_db_system.py", line 1693, in main
    handle_cfg()
    ~~~~~~~~~~^^
  File "/home/jessie13v2/Documents/gnumed/gnumed/server/bootstrap/./bootstrap_gm_db_system.py", line 1616, in handle_cfg
    if not bootstrap_bundles():
           ~~~~~~~~~~~~~~~~~^^
  File "/home/jessie13v2/Documents/gnumed/gnumed/server/bootstrap/./bootstrap_gm_db_system.py", line 1422, in bootstrap_bundles
    _PG_CLUSTER = cPostgresqlCluster()
  File "/home/jessie13v2/Documents/gnumed/gnumed/server/bootstrap/./bootstrap_gm_db_system.py", line 313, in __init__
    if not self.__bootstrap():
           ~~~~~~~~~~~~~~~~^^
  File "/home/jessie13v2/Documents/gnumed/gnumed/server/bootstrap/./bootstrap_gm_db_system.py", line 326, in __bootstrap
    if not self.__bootstrap_roles():
           ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/jessie13v2/Documents/gnumed/gnumed/server/bootstrap/./bootstrap_gm_db_system.py", line 430, in __bootstrap_roles
    if self.__create_gm_dbo() is None:
       ~~~~~~~~~~~~~~~~~~~~^^
  File "/home/jessie13v2/Documents/gnumed/gnumed/server/bootstrap/./bootstrap_gm_db_system.py", line 457, in __create_gm_dbo
    print_msg(__MSG_create_gm_dbo)
              ^^^^^^^^^^^^^^^^^^^
NameError: name '_cPostgresqlCluster__MSG_create_gm_dbo' is not defined
2026-02-25 21:12:32  ERROR     gm.bootstrapper  [140537027895552 MainThread]  (/home/jessie13v2/Documents/gnumed/gnumed/server/bootstrap/./bootstrap_gm_db_system.py::exit_with_msg() #1577): Bootstrapping failed: unhandled exception occurred