### PR TITLE
small fix: ensure __bootstrap_roles() catches errors or fails from __create_gm_dbo()

### DIFF
--- a/gnumed/gnumed/server/bootstrap/bootstrap_gm_db_system.py
+++ b/gnumed/gnumed/server/bootstrap/bootstrap_gm_db_system.py
@@ -429,7 +429,10 @@ class cPostgresqlCluster:
 			_log.error("Cannot create GNUmed standard groups roles.")
 			return None
 
-		if self.__create_gm_dbo() is None:
+		# if self.__create_gm_dbo() is None:
+		# __create_gm_dbo() does not return 'None' in current flow; 'is none' doesn't trigger properly
+
+		if not self.__create_gm_dbo():  # ensures fail is properly caught
 			_log.error("Cannot install GNUmed database owner.")
 			return None
 


### PR DESCRIPTION
- changes condition to 'if not' instead of 'if (...) is None'
- __create_gm_dbo() never returns "None" and so fails were not caught
- now properly caught and logged.