### PR TITLE
v15-v16 bootstrap stop: gm-dbo without admin in groups

### DIFF
--- a/gnumed/gnumed/server/bootstrap/bootstrap_gm_db_system.py
+++ b/gnumed/gnumed/server/bootstrap/bootstrap_gm_db_system.py
@@ -433,6 +433,10 @@ class cPostgresqlCluster:
 			_log.error("Cannot install GNUmed database owner.")
 			return False
 
+		if not self.__grant_gm_dbo_group_admin():
+			_log.error('Cannot grant [%s] admin option on GNUmed standard group roles.', _GM_DBO_ROLE)
+			return False
+
 		return True
 
 	#--------------------------------------------------------------
@@ -446,6 +450,24 @@ class cPostgresqlCluster:
 		cursor = self.conn_superuser_at_maintenance_db.cursor()
 		for group in groups:
 			if not gmPG2.create_group_role(group_role = group, link_obj = cursor):
+				cursor.close()
+				return False
+
+		self.conn_superuser_at_maintenance_db.commit()
+		cursor.close()
+		return True
+
+	#--------------------------------------------------------------
+	def __grant_gm_dbo_group_admin(self) -> bool:
+		section = "GnuMed defaults"
+		groups = cfg_get(section, "groups")
+		if groups is None:
+			_log.error("Cannot load GNUmed group names from config file (section [%s])." % section)
+			return False
+
+		cursor = self.conn_superuser_at_maintenance_db.cursor()
+		for group in groups:
+			if not gmPG2.create_group_role(group_role = group, admin_role=_GM_DBO_ROLE 	,link_obj = cursor):
 				cursor.close()
 				return False
 


### PR DESCRIPTION
Testing latest master branch, with (...)local_first.conf and (...)local_last.conf files commented out. (That change works great, no more trouble getting groups list!!)

During v15-v16 bootstrapping, process stops. Full log attached.
[bootstrap-latest_1_202603041343.log](https://github.com/user-attachments/files/25752016/bootstrap-latest_1_202603041343.log)

Specifically at that step gm-dbo does not have sufficient rights to grant those roles... proposed fix: add method to grant ADMIN to gm-dbo in groups from configs. The method is basically a clone of __create_groups(), with just the admin_role value added to gmPG2.create_group_role() execution.The whole thing is executed after gm-dbo creation.

Tested on trixie. Latest master branch + this makes boostrap-latest.sh run smoothly on first run.

As far as I understand, this should not hide any deeper problems?

María