### PR TITLE
very small bug: just added back gm-logins to .conf files

### DIFF
--- a/gnumed/gnumed/server/bootstrap/bootstrap-archive.conf
+++ b/gnumed/gnumed/server/bootstrap/bootstrap-archive.conf
@@ -93,6 +93,7 @@ $schema$
 [GnuMed defaults]
 
 groups = $groups$
+gm-logins
 gm-doctors
 gm-staff_medical
 gm-staff_office

--- a/gnumed/gnumed/server/bootstrap/bootstrap-monolithic_core.conf
+++ b/gnumed/gnumed/server/bootstrap/bootstrap-monolithic_core.conf
@@ -156,6 +156,7 @@ $schema$
 
 groups = $groups$
 gnumed_v2
+gm-logins
 gm-doctors
 gm-staff_medical
 gm-staff_office


### PR DESCRIPTION
Hello, Karsten!

Testing the latest changes, got an almost inmediate error when running the bootstrap. Log attached!
[bootstrap-latest_20260305_1.log](https://github.com/user-attachments/files/25774357/bootstrap-latest_20260305_1.log)

Automatically just added gm-logins back to the conf files and it worked.

Investigating the reason, since gm-logins is hardcoded also, it seems that because __setup_groups() gets the list of groups to create from the conf files, when gm-logins is not on those it does not get created, so that when the hardcoded variable is used inside the SQL query within __create_gm_dbo(), it fails -- role "gm-logins" does not exist.

This PR is just adding those "gm-logins" back to the .conf files, and now everything works! Bootstrap works out-of-the-box :)

María