### PR TITLE
Incoming plugin unhandled exception: add support for non-.get_pydt() dates

### DIFF
--- a/gnumed/gnumed/client/wxpython/gmIncomingDataWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmIncomingDataWidgets.py
@@ -564,7 +564,11 @@ class cIncomingPluginPnl(wxgIncomingPluginPnl.wxgIncomingPluginPnl, gmRegetMixin
 		new_doc['pk_org_unit'] = self._PhWheel_source.GetData()
 		date = self._PhWheel_doc_date.GetData()
 		if date is not None:
-			new_doc['clin_when'] = date.get_pydt()
+			if hasattr(date, 'get_pydt'): 	# Protection against getting different date types
+				new_doc['clin_when'] = date.get_pydt()
+			else:
+				new_doc['clin_when'] = date
+
 		comment = self._PRW_doc_comment.GetLineText(0).strip()
 		if comment:
 			new_doc['comment'] = comment


### PR DESCRIPTION
When trying to import an item to a patient's chart within the Incoming Area plugin, I got this unhandled exception:

type: <class 'AttributeError'>
value: 'datetime.datetime' object has no attribute 'get_pydt'
  File "/home/jessie/Documents/Informática/codes/gnumed_github/gnumed/gnumed/Gnumed/wxpython/gmIncomingDataWidgets.py", line 568, in _on_save_button_pressed
    new_doc['clin_when'] = date.get_pydt()
                           ^^^^^^^^^^^^^

Full log attached.
[gm-vcs-03_15--14_39_34--11704_STOP_INCOMING.log](https://github.com/user-attachments/files/26009436/gm-vcs-03_15--14_39_34--11704_STOP_INCOMING.log)

Proposed fix: added conditional handling for when (if) this plugin ever gets a date that has .get_pydt() as attribute. Otherwise, date is used as-is.

Tested and could then import to patient's charts without stops.

From what I could tell though, Incoming plugin should really never get a fuzzy date that needs .get_pydt()? Did not take out that option though, just in case :)