### PR TITLE
non-vital, UI-only - gmIncomingDataWidgets.py: small column width change

### DIFF
--- a/gnumed/gnumed/client/wxpython/gmIncomingDataWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmIncomingDataWidgets.py
@@ -50,12 +50,15 @@ _log = logging.getLogger('gm.auto-in-ui')
 #============================================================
 class cIncomingDataListCtrl(gmListWidgets.cReportListCtrl):
 
+	_INCOMING_COL_INITIAL_WIDTH = 460 # still comfortable width for restricted displays
+
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
 		if not self.EnableCheckBoxes(enable = True):
 			_log.error('cannot enable list item checkboxes')
 		self.set_columns(columns = [_('Incoming document'), _('Patient')])
-		self.set_column_widths([wx.LIST_AUTOSIZE, wx.LIST_AUTOSIZE])
+		self.set_column_widths([self._INCOMING_COL_INITIAL_WIDTH, wx.LIST_AUTOSIZE])
+		self.set_resize_column(column = 1)
 
 	#--------------------------------------------------------
 	def repopulate(self, pk_patient=None) -> bool:


### PR DESCRIPTION
Very small, non-vital, UI-only fix:

Made column width of 'Incoming document' column in Incoming plugin a fixed width, so that the 'Patient' column is visible when first entering the plugin.

Otherwise, when opening the plugin and if there are any items already dropped into the incoming area and waiting to be imported, the 'Incoming documents' column can get too wide and thus 'hide' the 'Patient' column...

Tested on restricted displays as well and I think it is still comfortable. The user can still move the column widths around if they would like to.

Regards,
María