### PR TITLE
Make encounter widget refresh on edit

### DIFF
--- a/gnumed/gnumed/client/wxpython/gmEncounterWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmEncounterWidgets.py
@@ -570,6 +570,10 @@ class cEncounterEditAreaPnl(wxgEncounterEditAreaPnl.wxgEncounterEditAreaPnl):
 		self.__encounter.generic_codes_rfe = [ c['data'] for c in self._PRW_rfe_codes.GetData() ]
 		self.__encounter.generic_codes_aoe = [ c['data'] for c in self._PRW_aoe_codes.GetData() ]
 
+		active_enc = gmPerson.gmCurrentPatient().emr.active_encounter
+		if active_enc['pk_encounter'] == self.__encounter['pk_encounter']:
+			gmDispatcher.send(signal = 'current_encounter_modified')
+
 		return True
 
 #----------------------------------------------------------------

--- a/gnumed/gnumed/client/wxpython/gmNarrativeWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmNarrativeWidgets.py
@@ -514,6 +514,8 @@ class cFancySoapEditorPnl(wxgFancySoapEditorPnl.wxgFancySoapEditorPnl):
 		enc.generic_codes_rfe = [ c['data'] for c in self._PRW_rfe_codes.GetData() ]
 		enc.generic_codes_aoe = [ c['data'] for c in self._PRW_aoe_codes.GetData() ]
 
+		gmDispatcher.send(signal = 'current_encounter_modified')
+
 		return True
 	#--------------------------------------------------------
 	# internal helpers


### PR DESCRIPTION
When saving changes to encounter information -- such as type, RFE or AOE -- the Active Encounter panel did not update accordingly.

Specifically, when saving changes through the 'edit encounter details' pop-up, and then also when editing RFE and AOE from the SOAP notes plugin.

To reproduce:
- From the 'edit encounter details' pop-up:
double-click on Active Encounter panel -> change encounter type, for example -> save and close pop-up -> change to encounter type not shown on Active Encounter panel widget.

- From the SOAP notes plugin:
write anything in the 'Summary' field -> save encounter changes by clicking the 'Encounter: Save' button at the bottom of the SOAP plugin -> information not updated on the Active Encounter panel text nor its tooltip.

Proposed fix:
- added flags that current encounter was modified
- tested on trixie and works smoothly.

Regards,
María