### PR TITLE
Make changes to plugins to load & plugin tab positions stick

### DIFF
--- a/gnumed/gnumed/client/pycommon/gmCfgDB.py
+++ b/gnumed/gnumed/client/pycommon/gmCfgDB.py
@@ -77,7 +77,7 @@ def get4site(option:str=None, default=None):
 	return __get_db_cfg_object().get4site(option = option, default = default)
 
 #------------------------------------------------------------------
-def set(owner:str=None, workplace:str=None, cookie:str=None, option:str=None, value=None) -> bool:
+def set(owner:str='', workplace:str=None, cookie:str=None, option:str=None, value=None) -> bool:
 	"""Set configuration value.
 
 	Calls set(...) on a module global instance of cCfgSQL().
@@ -254,7 +254,7 @@ class cCfgSQL:
 		return self.__get4site(option = option, default = default)
 
 	#----------------------------
-	def set(self, owner:str=None, workplace:str=None, cookie:str=None, option:str=None, value=None, description:str=None) -> bool:
+	def set(self, owner:str='', workplace:str=None, cookie:str=None, option:str=None, value=None, description:str=None) -> bool:
 		"""Set (create or update) option+value in database.
 
 		Any argument that is None will be set to NULL, meaning site-wide default.
@@ -386,7 +386,7 @@ class cCfgSQL:
 				return None
 
 			_log.info('setting site-wide default for option [%s] to [%s]' % (option, default))
-			self.set(option = option, value = default)
+			self.set(option = option, value = default, owner = None)
 			return default
 
 		return self.__auto_heal_pseudo_boolean_setting(setting = rows[0], default = default)


### PR DESCRIPTION
With current master, tab position changes and also changes to Workplace plugins to load done from...
GNUmed -> Master data -> Manage lists -> Workplace profiles (which plugins to load)
... are not properly found and applied for next session.

Full logs attached from client runs trying to change these settings:
- Where I changed tab position to 'bottom':
[gm-vcs-03_26--16_08_04--82748_tried_change_tab_position.log](https://github.com/user-attachments/files/26287005/gm-vcs-03_26--16_08_04--82748_tried_change_tab_position.log)
- Where no tab position changes were seen + I tried to add another plugin to load ('xDT viewer'):
[gm-vcs-03_26--16_09_01--83103_tried_add_plugin_to_load_xdtviewer.log](https://github.com/user-attachments/files/26287030/gm-vcs-03_26--16_09_01--83103_tried_add_plugin_to_load_xdtviewer.log)
- Inmediate next run, where xDT viewer plugin was not loaded:
[gm-vcs-03_26--16_11_03--83675_changes_not_applied_run.log](https://github.com/user-attachments/files/26287067/gm-vcs-03_26--16_11_03--83675_changes_not_applied_run.log)

At first I thought maybe things were not written/saved properly, but after further investigation, this is what I could understand: these changes were being saved/written into the db with 'owner' set as NULL, which made it so that when get4user(...) tried to actually read the configs/changes set by the user, it could not find them properly, resulting in changes not showing on next login.

My proposed fix:
- Use...
owner = ''
... for set() function and for cCfgSQL -> set() method, making it so changes are written with current_user as owner by default.

- Then since the default is now owner = '', specify...
owner = None
...when calling self.set() within in __get4site() method, still within cCfgSQL.

Tested on trixie, and these modifications made changes to both plugin tab positions and plugins to load show on next sessions. I think the mods made other user-set configurations also be properly found and applied, just tested these two though because they are the ones I change for my own user :) Happy to test any others!

María