### PR TITLE
Update __get_visual_progress_notes_editor() dispatcher msg

### DIFF
--- a/gnumed/gnumed/client/wxpython/gmVisualProgressNoteWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmVisualProgressNoteWidgets.py
@@ -211,7 +211,7 @@ def __get_visual_progress_notes_editor(filename:str=None) -> str:
 	if editor:
 		return editor
 
-	gmDispatcher.send(signal = 'statustext', msg = _('Editor for visual progress note left configured.'), beep = True)
+	gmDispatcher.send(signal = 'statustext', msg = _('Editor for visual progress note left unconfigured.'), beep = True)
 	return None
 
 #------------------------------------------------------------


### PR DESCRIPTION
While checking/updating the Spanish translation, found an oddly-phrased string:

'Editor for visual progress note left configured.'

Looking at the code, it seems like the real intent was to say that editor was left unconfigured? At least, as far as I could tell from the function itself...

Just added "un-" to the message :)

María