### PR TITLE
Some translation comments + very small string changes

### DIFF
--- a/gnumed/gnumed/client/wxGladeWidgets/wxgExportAreaExportToMediaDlg.py
+++ b/gnumed/gnumed/client/wxGladeWidgets/wxgExportAreaExportToMediaDlg.py
@@ -45,7 +45,7 @@ class wxgExportAreaExportToMediaDlg(wx.Dialog):
 
 	def __set_properties(self):
 		# begin wxGlade: wxgExportAreaExportToMediaDlg.__set_properties
-		self.SetTitle(_("Creating Patient Media"))
+		self.SetTitle(_("Creating Patient Media##tx:as in, removable media w/ patient data"))
 		self.SetSize((700, 500))
 		self._BTN_reload_media_list.SetToolTip(_("Reload the list of removable media."))
 		self._LBL_directory.SetFont(wx.Font(9, wx.DEFAULT, wx.SLANT, wx.NORMAL, 0, ""))

--- a/gnumed/gnumed/client/wxGladeWidgets/wxgSelectablySortedDocTreePnl.py
+++ b/gnumed/gnumed/client/wxGladeWidgets/wxgSelectablySortedDocTreePnl.py
@@ -23,7 +23,7 @@ class wxgSelectablySortedDocTreePnl(wx.ScrolledWindow):
 		__lbl_sort = wx.StaticText(self, wx.ID_ANY, _("Sort documents by"))
 		__szr_top_radio.Add(__lbl_sort, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT | wx.RIGHT, 5)
 
-		self._rbtn_sort_by_age = wx.RadioButton(self, wx.ID_ANY, _("Age"), style=wx.RB_GROUP)
+		self._rbtn_sort_by_age = wx.RadioButton(self, wx.ID_ANY, _("Age##tx: sort documents displayed by age, newest first"), style=wx.RB_GROUP)
 		self._rbtn_sort_by_age.SetToolTip(_("Sort newest documents to top of tree."))
 		self._rbtn_sort_by_age.SetValue(1)
 		__szr_top_radio.Add(self._rbtn_sort_by_age, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 10)

--- a/gnumed/gnumed/client/wxg/wxgExportAreaExportToMediaDlg.wxg
+++ b/gnumed/gnumed/client/wxg/wxgExportAreaExportToMediaDlg.wxg
@@ -4,7 +4,7 @@
 <application encoding="UTF-8" for_version="3.0" header_extension=".h" indent_amount="1" indent_symbol="tab" is_template="0" language="python" option="0" overwrite="1" path="../wxGladeWidgets/wxgExportAreaExportToMediaDlg.py" source_extension=".cpp" top_window="ExportAreaExportToMediaDlg" use_gettext="1" use_new_namespace="1">
     <object class="wxgExportAreaExportToMediaDlg" name="ExportAreaExportToMediaDlg" base="EditDialog">
         <size>700, 500</size>
-        <title>Creating Patient Media</title>
+        <title>Creating Patient Media##tx:as in, removable media w/ patient data</title>
         <style>wxDEFAULT_DIALOG_STYLE|wxMAXIMIZE_BOX|wxMINIMIZE_BOX|wxRESIZE_BORDER</style>
         <object class="wxBoxSizer" name="__szr_main" base="EditBoxSizer">
             <orient>wxVERTICAL</orient>

--- a/gnumed/gnumed/client/wxpython/gmBillingWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmBillingWidgets.py
@@ -814,7 +814,7 @@ def remove_items_from_bill(parent=None, bill=None):
 		],
 		show_checkbox = True,
 		checkbox_msg = _('Also remove invoice PDF'),
-		checkbox_tooltip = _('Also remove the invoice PDF from the document archive (because it will not correspond to the bill anymore).')
+		checkbox_tooltip = _('MAKE SURE THIS IS LAWFUL !\n\nAlso remove the invoice PDF from the document archive (because it will not correspond to the bill anymore).')
 	)
 	button_pressed = dlg.ShowModal()
 	delete_invoice = dlg.checkbox_is_checked()

--- a/gnumed/gnumed/client/wxpython/gmBillingWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmBillingWidgets.py
@@ -924,7 +924,7 @@ def manage_bills(parent=None, patient=None):
 		items = []
 		for b in bills:
 			if b['close_date'] is None:
-				close_date = _('<open>')
+				close_date = _('<open>##tx: open state of a bill')
 			else:
 				close_date = b['close_date'].strftime('%Y %b %d')
 			if b['total_amount'] is None:

--- a/gnumed/gnumed/client/wxpython/gmBillingWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmBillingWidgets.py
@@ -800,9 +800,8 @@ def remove_items_from_bill(parent=None, bill=None):
 		question = _(
 			'%s items selected from bill (invoice ID "%s")\n'
 			'\n'
-			'Do you want to only remove the selected items\n'
-			'from the bill ("unbill" them) or do you want\n'
-			'to delete them entirely from the patient ?\n'
+			'Do you want to only remove the selected items from the bill ("unbill" them)\n'
+			'or do you want to delete them entirely from the patient ?\n'
 			'\n'
 			'Note that neither action is reversible.'
 		) % (

--- a/gnumed/gnumed/client/wxpython/gmGuiMain.py
+++ b/gnumed/gnumed/client/wxpython/gmGuiMain.py
@@ -788,7 +788,7 @@ class gmTopLevelFrame(wx.Frame):
 		self.Bind(wx.EVT_MENU, self.__on_show_log_file, item)
 		item = menu_log.Append(-1, _('save'), _('Backup content of the log to another file.'))
 		self.Bind(wx.EVT_MENU, self.__on_backup_log_file, item)
-		item = menu_log.Append(-1, _('email'), _('Send log file to the authors for help.'))
+		item = menu_log.Append(-1, _('email##tx: as a verb, send log to developers'), _('Send log file to the authors for help.'))
 		self.Bind(wx.EVT_MENU, self.__on_email_log_file, item)
 
 		menu_browse = wx.Menu()


### PR DESCRIPTION
Hi!

Here added:

- Some hardcoded translation comments (found to be useful while updating the Spanish translation)
- Copied and repeated the lawfulness warning line to the second time gmBillingWidgets lets you delete the invoice PDFs
- Slight change in line skip, also in gmBillingWidgets, because the original strings had line breaks so as to make the next narrow, however, because the first line of the text inserts the invoice ID, the dialog window becomes wider and it causes the following text to look too narrow... the actual text was not changed, only took out one of the line skips to even things out...

María