### PR TITLE
gmBillingWidgets: add one translatable string

### DIFF
--- a/gnumed/gnumed/client/wxpython/gmBillingWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmBillingWidgets.py
@@ -962,7 +962,7 @@ def manage_bills(parent=None, patient=None):
 		delete_callback = delete,
 		refresh_callback = refresh,
 		middle_extra_button = (
-			'Invoice',
+			_('Invoice'),
 			_('Create if necessary, and show the corresponding invoice (PDF)'),
 			show_pdf
 		),


### PR DESCRIPTION
Just marked 'Invoice' button label as translatable.

From 'Billing' plugin -> 'Bills' button -> bottom right 'Invoice' button